### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-#jQuery Currency
+# jQuery Currency
 
 Simple, unobtrusive currency converting and formatting
 
-##Requirements
+## Requirements
 
 To use jQuery Currency you will need the following:
 
 * jQuery Version 1.5 - Version 2.1.3
 * PHP to perform foreign exchange conversions
 
-##Example Usage
+## Example Usage
 
 Format an element on a page, using Default Settings
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
